### PR TITLE
Fixes issue #47

### DIFF
--- a/tasks/lib/string-replace.js
+++ b/tasks/lib/string-replace.js
@@ -95,6 +95,7 @@ exports.init = function(grunt) {
         replace_done(false);
       }
         grunt.log.writeln('\n'+ chalk.cyan(counter) + ' files created');
+      counter = 0;
       replace_done();
     });
   };


### PR DESCRIPTION
Fixes https://github.com/eruizdechavez/grunt-string-replace/issues/47

Issue was caused due to `counter` variable getting incremented with every successful run.
Issue fix is to reset the variable before calling `replace_done()`